### PR TITLE
Create dotnet-api-build-test-publish.yml

### DIFF
--- a/.github/workflows/dotnet-api-build-test-publish.yml
+++ b/.github/workflows/dotnet-api-build-test-publish.yml
@@ -1,0 +1,34 @@
+name: dotnet-api-build-test-publish
+
+on:
+  workflow_call:
+    inputs:
+      api-name:
+        required: true
+        type: string
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+    - name: Publish
+      run: dotnet publish ${{ inputs.api-name }}/${{ inputs.api-name }}.csproj -c Release -o dist
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2.2.2
+      with:
+        name: ${{ inputs.api-name }}
+        path: dist/**
+        if-no-files-found: error


### PR DESCRIPTION
Add a reusable workflow that consists of build, test, and publish steps. This workflow can then be used in the ci and cd pipelines